### PR TITLE
Use python 2 instead of the system version

### DIFF
--- a/oclint-json-compilation-database
+++ b/oclint-json-compilation-database
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import platform


### PR DESCRIPTION
More and more systems are using python3 as their new standard version. The script does not work with python3 and should therefore set the python version explicitly.
